### PR TITLE
Update authors list in DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: dataDownloader
 Title: Downloads Files From Repositories If Hash Has Changed
 Version: 0.0.0.9002
 Authors@R: 
-    person(given = "Richard",
+    person(given = c("Richard", "James"),
            family = "Telford",
            role = c("aut", "cre"),
            email = "richard.telford@uib.no",


### PR DESCRIPTION
Using a "different" name than in other work makes bibtex think it is a different author and does annoying things with the reference list.